### PR TITLE
fix: over 21 check condition

### DIFF
--- a/game.js
+++ b/game.js
@@ -442,7 +442,7 @@ function play (autoplay) {
     let playerturn = true
     let dealerturn = false
     while (playerturn) {
-      if ((calcHand(playerHand) === 21) || (playerHand.length === 5 && (calcHand(playerHand) < 21 || calcHand(playerHand) > 21))) {
+      if (calcHand(playerHand) === 21 || (playerHand.length === 5 && calcHand(playerHand) < 21) || calcHand(playerHand) > 21) {
         playerturn = false
         dealerturn = true
         sleep(500)


### PR DESCRIPTION
Due to the change of bracket usage for code coverage, the check if the player has gone over 21 was not working as intended. Issue has been adressed, fixed and tested. Working again now.